### PR TITLE
Ensure https on embedded video players

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
                                 You can <a href="RELEASE/older-releases.html">download older releases</a> of Golden Cheetah.
                                 There is a <a href="https://github.com/GoldenCheetah/GoldenCheetah/wiki/UG_Main-Page_Users-Guide">User guide</a>
                                 and a <a href="https://github.com/GoldenCheetah/GoldenCheetah/wiki/FAQ">FAQ</a>.
-                                The full Golden Cheetah source code is freely available from <a href="http://github.com/GoldenCheetah/GoldenCheetah/tree/master/">Github</a>.
+                                The full Golden Cheetah source code is freely available from <a href="https://github.com/GoldenCheetah/GoldenCheetah/tree/master/">Github</a>.
                                 </div>
                             </div>
                             
@@ -225,7 +225,7 @@
                                 <div class="col-lg-12">
                                     <div class="align-center">
                                         <div class="testimonial clearfix" >
-                                            <center class="author center-block">&mdash; Photo : <a href="http://www.justinknotzke.com/">Justin Knotzke</a></center>
+                                            <center class="author center-block">&mdash; Photo : <a href="https://www.justinknotzke.com/">Justin Knotzke</a></center>
                                         </div>
                                     </div>
                                 </div>
@@ -685,12 +685,12 @@
                                 <h1>Tutorials</h1>
                                 
                                 <div class="col-md-3">
-                                    <a href="https://vimeo.com/191463556" id="vimeo1" data-remote="http://player.vimeo.com/video/191463556" data-toggle="ekkoLightbox" data-width="800" data-title="What's New in GoldenCheetah Version 3.4"><img src="img/NewGC34_video.png" class="img-responsive"/></a><BR>
+                                    <a href="https://vimeo.com/191463556" id="vimeo1" data-remote="https://player.vimeo.com/video/191463556" data-toggle="ekkoLightbox" data-width="800" data-title="What's New in GoldenCheetah Version 3.4"><img src="img/NewGC34_video.png" class="img-responsive"/></a><BR>
                                     <center>What's New in GoldenCheetah 3.4</center><BR>
                                 </div>
 
                                 <div class="col-md-3">
-                                    <a href="http://vimeo.com/192126358" id="vimeo2" data-remote="http://player.vimeo.com/video/192126358" data-toggle="ekkoLightbox" data-width="800" data-title="Workout Editor"><img src="img/WorkoutEditor_video.png" class="img-responsive"/></a><BR>
+                                    <a href="https://vimeo.com/192126358" id="vimeo2" data-remote="https://player.vimeo.com/video/192126358" data-toggle="ekkoLightbox" data-width="800" data-title="Workout Editor"><img src="img/WorkoutEditor_video.png" class="img-responsive"/></a><BR>
                                     <center>Workout Editor</center><BR>
                                 </div>
 
@@ -701,17 +701,17 @@
                             <div class="row">
           
                                 <div class="col-md-3">
-                                    <a href="http://vimeo.com/114132189" id="vimeo4" data-remote="http://player.vimeo.com/video/114132189" data-toggle="ekkoLightbox" data-width="800" data-title="Overview of the UI"><img src="img/UiOverview_video.png" class="img-responsive"/></a><BR>
+                                    <a href="https://vimeo.com/114132189" id="vimeo4" data-remote="https://player.vimeo.com/video/114132189" data-toggle="ekkoLightbox" data-width="800" data-title="Overview of the UI"><img src="img/UiOverview_video.png" class="img-responsive"/></a><BR>
                                     <center>Overview of the UI</center><BR>
                                 </div>
                                 
                                 <div class="col-md-3">
-                                    <a href="http://vimeo.com/100244204" id="vimeo5" data-remote="http://player.vimeo.com/video/100244204" data-toggle="ekkoLightbox" data-width="800" data-title="The Critical Power Chart"><img src="img/CPChart_video.png" class="img-responsive"/></a><BR>
+                                    <a href="https://vimeo.com/100244204" id="vimeo5" data-remote="https://player.vimeo.com/video/100244204" data-toggle="ekkoLightbox" data-width="800" data-title="The Critical Power Chart"><img src="img/CPChart_video.png" class="img-responsive"/></a><BR>
                                     <center>The Critical Power Chart</center><BR>
                                 </div>
 
                                 <div class="col-md-3">
-                                    <a href="http://vimeo.com/100599100" id="vimeo6" data-remote="http://player.vimeo.com/video/100599100" data-toggle="ekkoLightbox" data-width="800" data-                                title="W'bal"><img src="img/WprimeBal_video.png" class="img-responsive"/></a><BR>
+                                    <a href="https://vimeo.com/100599100" id="vimeo6" data-remote="https://player.vimeo.com/video/100599100" data-toggle="ekkoLightbox" data-width="800" data-                                title="W'bal"><img src="img/WprimeBal_video.png" class="img-responsive"/></a><BR>
                                     <center>W'bal</center><BR>
                                 </div>
 
@@ -719,12 +719,12 @@
                             <div class="row">
 
                                 <div class="col-md-3">
-                                    <a href="http://vimeo.com/101867214" id="vimeo7" data-remote="http://player.vimeo.com/video/101867214" data-toggle="ekkoLightbox" data-width="800" data-title="Metric Trends Chart"><img src="img/MetricTrendsChart_video.png" class="img-responsive"/></a><BR>
+                                    <a href="https://vimeo.com/101867214" id="vimeo7" data-remote="https://player.vimeo.com/video/101867214" data-toggle="ekkoLightbox" data-width="800" data-title="Metric Trends Chart"><img src="img/MetricTrendsChart_video.png" class="img-responsive"/></a><BR>
                                     <center>Metric Trends Chart</center><BR>
                                 </div>
                                 
                                 <div class="col-md-3">
-                                    <a href="http://vimeo.com/107577461" id="vimeo9" data-remote="http://player.vimeo.com/video/107577461" data-toggle="ekkoLightbox" data-width="800"                                 data-title="TrainingPeaks Upload/Download"><img src="img/MetadataSearchingFiltering_video.png" class="img-responsive"/></a><BR>
+                                    <a href="https://vimeo.com/107577461" id="vimeo9" data-remote="https://player.vimeo.com/video/107577461" data-toggle="ekkoLightbox" data-width="800"                                 data-title="TrainingPeaks Upload/Download"><img src="img/MetadataSearchingFiltering_video.png" class="img-responsive"/></a><BR>
                                     <center>Metadata, Searching and Filtering</center><BR>
                                 </div>
 
@@ -732,17 +732,17 @@
                             <div class="row">
 
                                 <div class="col-md-3">
-                                    <a href="http://vimeo.com/130530369" id="vimeo10" data-remote="http://player.vimeo.com/video/130530369" data-toggle="ekkoLightbox" data-width="800" data-title="Working with Intervals"><img src="img/Intervals_video.png" class="img-responsive"/></a><BR>
+                                    <a href="https://vimeo.com/130530369" id="vimeo10" data-remote="https://player.vimeo.com/video/130530369" data-toggle="ekkoLightbox" data-width="800" data-title="Working with Intervals"><img src="img/Intervals_video.png" class="img-responsive"/></a><BR>
                                     <center>Working with Intervals</center><BR>
                                 </div>
                                 
                                 <div class="col-md-3">
-                                    <a href="http://vimeo.com/111875430" id="vimeo11" data-remote="http://player.vimeo.com/video/111875430" data-toggle="ekkoLightbox" data-width="800" data-title="Download and Merge Data using a Moxy"><img src="img/MoxyData_video.png" class="img-responsive"/></a><BR>
+                                    <a href="https://vimeo.com/111875430" id="vimeo11" data-remote="https://player.vimeo.com/video/111875430" data-toggle="ekkoLightbox" data-width="800" data-title="Download and Merge Data using a Moxy"><img src="img/MoxyData_video.png" class="img-responsive"/></a><BR>
                                     <center>Download and Merge Data using a Moxy</center><BR>
                                 </div>
 
                                 <div class="col-md-3">
-                                    <a href="http://vimeo.com/151291424" id="vimeo12" data-remote="http://player.vimeo.com/video/151291424" data-toggle="ekkoLightbox" data-width="800"                                 data-title="Working with Train View"><img src="img/TrainView_video.png" class="img-responsive"/></a><BR>
+                                    <a href="https://vimeo.com/151291424" id="vimeo12" data-remote="https://player.vimeo.com/video/151291424" data-toggle="ekkoLightbox" data-width="800"                                 data-title="Working with Train View"><img src="img/TrainView_video.png" class="img-responsive"/></a><BR>
                                     <center>Working with Train View</center><BR>
                                 </div>
 
@@ -750,17 +750,17 @@
                             <div class="row">
 
                                 <div class="col-md-3">
-                                    <a href="http://vimeo.com/99817526" id="vimeo13" data-remote="http://player.vimeo.com/video/99817526" data-toggle="ekkoLightbox" data-width="800" data-title="What's New in GoldenCheetah Version 3.1"><img src="img/NewGC31_video.png" class="img-responsive"/></a><BR>
+                                    <a href="https://vimeo.com/99817526" id="vimeo13" data-remote="https://player.vimeo.com/video/99817526" data-toggle="ekkoLightbox" data-width="800" data-title="What's New in GoldenCheetah Version 3.1"><img src="img/NewGC31_video.png" class="img-responsive"/></a><BR>
                                     <center>What's New in GoldenCheetah 3.1</center><BR>
                                 </div>
                                 
                                 <div class="col-md-3">
-                                    <a href="https://vimeo.com/135905103" id="vimeo14" data-remote="http://player.vimeo.com/video/135905103" data-toggle="ekkoLightbox" data-width="800" data-title="What's New in GoldenCheetah Version 3.2"><img src="img/NewGC32_video.png" class="img-responsive"/></a><BR>
+                                    <a href="https://vimeo.com/135905103" id="vimeo14" data-remote="https://player.vimeo.com/video/135905103" data-toggle="ekkoLightbox" data-width="800" data-title="What's New in GoldenCheetah Version 3.2"><img src="img/NewGC32_video.png" class="img-responsive"/></a><BR>
                                     <center>What's New in GoldenCheetah 3.2</center><BR>
                                 </div>
 
                                 <div class="col-md-3">
-                                    <a href="https://vimeo.com/145425005" id="vimeo15" data-remote="http://player.vimeo.com/video/145425005" data-toggle="ekkoLightbox" data-width="800" data-title="What's New in GoldenCheetah Version 3.3"><img src="img/NewGC33_video.png" class="img-responsive"/></a><BR>
+                                    <a href="https://vimeo.com/145425005" id="vimeo15" data-remote="https://player.vimeo.com/video/145425005" data-toggle="ekkoLightbox" data-width="800" data-title="What's New in GoldenCheetah Version 3.3"><img src="img/NewGC33_video.png" class="img-responsive"/></a><BR>
                                     <center>What's New in GoldenCheetah 3.3</center><BR>
                                 </div>
 
@@ -780,7 +780,7 @@
                                     <div class="align-center">
                                         <div class="testimonial clearfix" >
                                             <div class="testimonial clearfix" >
-                                                <center class="author center-block">&mdash; Photo : <a href="http://www.nknotzke.com/">Justin Knotzke</a></center>
+                                                <center class="author center-block">&mdash; Photo : <a href="https://www.justinknotzke.com/">Justin Knotzke</a></center>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
If you're browsing https://www.goldencheetah.org/#section-tutorials - then the tutorial videos won't play inline due to a mixed content error being thrown by Chrome (I think this used to be just a warning - not any more).

This patch cleans up the URLs to be https for all the embedded video players.